### PR TITLE
新規登録画面、ログイン画面のUI実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,3 +1,4 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+@import url('https://fonts.googleapis.com/css2?family=Chango&family=Noto+Sans+JP:wght@100..900&display=swap');
 @import 'top';

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -1,3 +1,8 @@
+body {
+  font-family: "Noto Sans JP", sans-serif;
+  color: #6c757d; 
+}
+
 .custom-bg {
   background-color: rgb(255, 255, 155); /* 任意の色に変更 */
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 
   <body>
     <% unless current_page?(root_path) %> 
-       <%= render 'shared/header' %>
+      <%= render user_signed_in? ? 'shared/header' : 'shared/before_sign_in_header' %>
     <% end %>
     <%= render 'shared/flash_message' %> 
     <%= yield %>

--- a/app/views/shared/_before_sign_in_header.html.erb
+++ b/app/views/shared/_before_sign_in_header.html.erb
@@ -1,0 +1,7 @@
+<header>
+  <nav class="navbar navbar-expand-lg custom-bg">
+    <div class="container-fluid">
+      <%= link_to image_tag('logo.png', height: "100"), root_path %>
+    </div>
+  </nav>
+</header>

--- a/app/views/shared/_before_sign_in_header.html.erb
+++ b/app/views/shared/_before_sign_in_header.html.erb
@@ -1,7 +1,7 @@
 <header>
-  <nav class="navbar navbar-expand-lg custom-bg">
+  <nav class="navbar navbar-expand-sm custom-bg py-md-4">
     <div class="container-fluid">
-      <%= link_to image_tag('logo.png', height: "100"), root_path %>
+      <%= link_to image_tag('logo.png', height: "60"), root_path %>
     </div>
   </nav>
 </header>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
-<footer class="d-flex justify-content-center align-items-center custom-bg" style="height:80px">
-  <div class="container text-center">
+<footer class="d-flex justify-content-center align-items-center custom-bg" >
+  <div class="container text-center py-3">
     <small>© 2024 Did it All Rights Reserved.</small>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,16 +1,16 @@
 <header>
-  <nav class="navbar navbar-expand-lg custom-bg">
+  <nav class="navbar navbar-expand-sm custom-bg py-md-4">
     <div class="container-fluid">
-      <%= link_to image_tag('logo.png', height: "100"), root_path %>
+      <%= link_to image_tag('logo.png', height: "60"), root_path %>
         
-      <div class="d-none d-md-block">
+      <div class="d-none d-sm-block">
         <%= link_to "#" do %>
           <button type="button" class= "btn btn-primary custom-btn">
             <i class="bi bi-person-circle"></i> マイページ
           </button>
         <% end %>
       </div>
-      <div class="d-md-none">
+      <div class="d-s-mnone">
         <%= link_to "#" do %>
           <i class="bi bi-person-circle" style="font-size: 2rem; "></i>
         <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,14 +3,14 @@
     <div class="container-fluid">
       <%= link_to image_tag('logo.png', height: "100"), root_path %>
         
-      <div class="d-none d-lg-block">
-        <button type="button" class="btn btn-outline-light">
-          <%= link_to "#" do %>
+      <div class="d-none d-md-block">
+        <%= link_to "#" do %>
+          <button type="button" class= "btn btn-primary custom-btn">
             <i class="bi bi-person-circle"></i> マイページ
-          <% end %>
-        </button>
+          </button>
+        <% end %>
       </div>
-      <div class="d-lg-none">
+      <div class="d-md-none">
         <%= link_to "#" do %>
           <i class="bi bi-person-circle" style="font-size: 2rem; "></i>
         <% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,29 +1,36 @@
-<h2><%= t('.sign_up') %></h2>
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-8 mx-auto mt-3 mb-3">
+      <h2 class="text-center"><%= t('.sign_up') %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render 'shared/error_messages', object: f.object %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+      
+        <div class="mb-3">
+          <%= f.label :email, class: "form-label" %><br />
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+        </div>
+      
+        <div class="mb-3">
+          <%= f.label :password, class: "form-label" %>
+          <% if @minimum_password_length %>
+          <small><%= t('users.shared.minimum_password_length', count: @minimum_password_length) %></small>
+          <% end %><br />
+          <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+        </div>
+      
+        <div class="mb-3">
+          <%= f.label :password_confirmation, class: "form-label" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+        </div>
+      
+        <div class="actions text-center mb-3">
+          <%= f.submit t('.sign_up'), class: "btn btn-primary custom-btn" %>
+        </div>
+      <% end %>
+      <div class='text-center '>
+        <%= link_to t('.to_login_page'), new_user_session_path %>
+      </div>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit t('.sign_up') %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-lg-8 mx-auto mt-3 mb-3">
+    <div class="col-md-10 col-lg-6 mx-auto mt-3 mb-3">
       <h2 class="text-center"><%= t('.sign_up') %></h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,28 +1,34 @@
-<h2><%= t('.sign_in') %></h2>
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-6 mx-auto mt-3 mb-3">
+      <h2 class="text-center"><%= t('.sign_in') %></h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <%= render 'shared/error_messages', object: f.object %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+      
+        <div class="mb-3">
+          <%= f.label :email, class: "form-label" %><br />
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+        </div>
+      
+        <div class="mb-3">
+          <%= f.label :password, class: "form-label" %><br />
+          <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
+        </div>
+      
+        <% if devise_mapping.rememberable? %>
+          <div class="mb-3">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me, class: "form-label"%>
+          </div>
+        <% end %>
+      
+        <div class="actions text-center mb-3">
+          <%= f.submit t('.sign_in'), class: "btn btn-primary custom-btn" %>
+        </div>
+      <% end %>
+      
+      <%= render "users/shared/links" %>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit t('.sign_in') %>
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -102,6 +102,7 @@ ja:
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
         sign_up: アカウント登録
+        to_login_page: ログインページへ
       signed_up: アカウント登録が完了しました。
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
       signed_up_but_locked: アカウントがロックされているためログインできません。


### PR DESCRIPTION
Closes #52 

##実装内容
- ヘッダーフッターの出し分け（ログイン前後のマイページへのリンク）
- bodyのフォントの色をsecondaryに変更
- フォントをgooglefontの"Noto Sans JP”に変更　（大きい文字を太く表示する）
- ヘッダーフッターのレイアウト調整