### PR TITLE
保護者メニュー画面の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,4 +6,8 @@ class UsersController < ApplicationController
     @child = Child.new
   end
 
+  def menu
+    @user = User.find(params[:id])
+  end
+  
 end

--- a/app/views/children/_form.html.erb
+++ b/app/views/children/_form.html.erb
@@ -4,7 +4,7 @@
       <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :name, t('children.register_form'), class: "form-label" %>
       <%= f.text_field :name, class: "form-control mb-2", placeholder: t('children.input_nickname') %>
-      <%= f.submit class: "btn btn-primary custom-btn" %>
+      <%= f.submit class: "btn btn-primary custom-btn", role: "button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
       <div class="d-none d-sm-block">
         <%= link_to user_path(current_user) do %>
           <button type="button" class= "btn btn-primary custom-btn">
-            <i class="bi bi-person-circle"></i> <%= t("defaults.buttons.user_page") %>
+            <i class="bi bi-person-circle"></i> <%= t("defaults.user_page") %>
           </button>
         <% end %>
       </div>

--- a/app/views/users/menu.html.erb
+++ b/app/views/users/menu.html.erb
@@ -1,0 +1,30 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-6 mx-auto">
+      <h5 class="mt-2"><%= t('.title') %></h5>
+      <div class="border border-1 rounded-3 text-center">
+        <div class="mt-2">
+          <%= link_to t(".children_infomation"), "#", class: "btn btn-primary custom-btn", role: "button" %>
+        </div>
+        <div class="mt-2">
+          <%= link_to t(".email_change"), "#", class: "btn btn-secondary", role: "button" %>
+        </div>
+        <div class="mt-2">
+          <%= link_to t(".password_change"), "#", class: "btn btn-secondary", role: "button" %>
+        </div>
+        <div class="mt-2">
+          <%= link_to t("users.sessions.sign_out"), destroy_user_session_path, class: "btn btn-primary custom-btn", role: "button", data: { turbo_method: :delete } %>
+        </div>
+        <div class="mt-2">  
+          <%= link_to t(".contact"), "#", class: "btn btn-secondary", role: "button" %>
+        </div>
+        <div class="mt-2">  
+          <%= link_to t("users.registrations.destroy"),user_registration_path, class: "btn btn-primary custom-btn", role: "button", data: { turbo_method: :delete, turbo_confirm: t("defaults.confirm_delete") } %>
+        </div>
+        <div class="my-2">  
+          <%= link_to t("defaults.previous_page"), user_path(current_user), class: "btn btn-primary custom-btn", role: "button" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
           <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
             <ul class="navbar-nav ms-auto my-2 mb-lg-0">
               <li class="nav-item">
-                <%= link_to t("defaults.buttons.user_menu"), "#", class: "btn btn-primary btn-sm custom-btn" %>
+                <%= link_to t("defaults.user_menu"), menu_user_path(@user), class: "btn btn-primary custom-btn" %>
               </li>
             </ul>
           </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -90,6 +90,7 @@ ja:
       updated: パスワードが正しく変更されました。
       updated_not_active: パスワードが正しく変更されました。
     registrations:
+      destroy: アカウント削除
       destroyed: アカウントを削除しました。
       edit:
         are_you_sure: 本当によろしいですか？
@@ -114,6 +115,7 @@ ja:
       already_signed_out: 既にログアウト済みです。
       new:
         sign_in: ログイン
+      sign_out: ログアウト
       signed_in: ログインしました。
       signed_out: ログアウトしました。
     shared:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -182,15 +182,15 @@ ja:
       short: "%m/%d %H:%M"
     pm: 午後
   defaults:
+    previous_page: もどる
     confirm_delete: 削除してよろしいですか？
     sign_up: アカウント登録
     sign_in: ログイン
     flash_message:
       created: "%{item}を登録しました"
       not_created: "%{item}を登録できませんでした"
-    buttons:
-      user_page: 保護者ページ
-      user_menu: 保護者メニュー
+    user_page: 保護者ページ
+    user_menu: 保護者メニュー
   activerecord:
     models:
       child: お子さま
@@ -200,6 +200,12 @@ ja:
   users:
     show:
       title: 保護者ページ
+    menu:
+      title: 保護者メニュー
+      children_infomation: お子さま登録状況
+      email_change: 登録メールアドレスの変更
+      password_change: パスワード変更
+      contact: お問いあわせ
   children:
     child_index: お子さま一覧
     please_register: お子さまを登録してください

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[show] do
     resources :children, shallow: true
+    get 'menu', on: :member
   end
 
 end


### PR DESCRIPTION
Closes #20 

## 実装内容
- routes.rbにルーティングを追加
- menu.html.erbを作成
- users_cotrollerにmenuアクションを追加
- user_pageからuser_menu_pageへの遷移

## 確認ポイント
- ログアウトができる
- ログアウト後、TOPページに遷移する
- アカウントの削除ができる
- アカウント削除後、TOPページに遷移する
- もどるボタンでマイページへ遷移する

## 補足
 - お子さま登録状況機能は後日実装
- 登録アドレス・パスワードの変更機能は後日実装
- お問い合わせ画面は後日実装
