### PR TITLE
お子さま登録状況ページの実装

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,5 +1,10 @@
 class ChildrenController < ApplicationController
 
+  def index
+    @is_user_children = request.path == user_children_path(current_user)
+    @children = current_user.children
+  end
+  
   def create
     @child = current_user.children.build(child_params)
 
@@ -13,7 +18,7 @@ class ChildrenController < ApplicationController
   def destroy
     @child = current_user.children.find(params[:id])
     @child.destroy
-    redirect_to user_path(current_user), status: :see_other, success: t('.success')
+    redirect_to user_children_path(current_user), status: :see_other, success: t('.success')
   end
 
   private

--- a/app/views/children/_child.html.erb
+++ b/app/views/children/_child.html.erb
@@ -1,19 +1,17 @@
-  <div class="mx-3 my-3 text-center" id="index-child">
-    <h4><%= t('children.child_index') %></h4>
-    <div class="my-3" style="display: flex; justify-content: center; flex-wrap: wrap;">
-      <% if children.empty? %>
-        <p><%= t('children.please_register') %></p>
-      <% else %>
-        <div class="d-flex flex-column mb-3">
-          <% children.each do |child| %>    
-            <div class="border border-warning border-5 rounded-3 text-center py-2 mb-2" style="width: 200px;" > 
-              <%= child.name %>
-              <%= link_to child_path(child), class: 'delete-child-link' , data: {turbo_method: :delete,  turbo_confirm: t("defaults.confirm_delete")} do %>
-                <i class="bi bi-trash-fill"></i>
-              <% end %>
-            </div>
-          <% end %>
+<% if children.empty? %>
+  <p><%= t('children.please_register') %></p>
+<% else %>
+  <% children.each do |child| %>
+    <div class="container d-flex flex-sm-row flex-column justify-content-center align-items-center mb-3">
+      <div class="border border-warning border-5 rounded-3 text-center py-2" style="width: 200px;" > 
+        <%= child.name %>
+      </div>
+      <% if @is_user_children %>
+        <div class="mx-3 d-flex">
+          <%= link_to t('children.index.edit'), edit_child_path(child), class: "btn btn-primary btn-sm custom-btn mx-1", role: "button" %>
+          <%= link_to t('children.index.destroy'), child_path(child), class: "btn btn-primary btn-sm custom-btn mx-1", role: "button", data: { turbo_method: :delete, turbo_confirm: t("defaults.confirm_delete") } %>
         </div>
       <% end %>
     </div>
-  </div>
+  <% end %>
+<% end %>

--- a/app/views/children/index.html.erb
+++ b/app/views/children/index.html.erb
@@ -1,0 +1,16 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-6 mx-auto">
+      <h5 class="mt-2"><%= t('.title') %></h5>
+      <div class="border border-1 rounded-3 text-center mb-3">
+        <div class="row py-3">
+            <%= render 'children/child', children: @children %>
+          </div>
+          <div class="mb-3">
+            <%= link_to t("defaults.previous_page"), menu_user_path(current_user), class: "btn btn-primary custom-btn", role: "button" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/menu.html.erb
+++ b/app/views/users/menu.html.erb
@@ -2,9 +2,9 @@
   <div class="row">
     <div class="col-md-10 col-lg-6 mx-auto">
       <h5 class="mt-2"><%= t('.title') %></h5>
-      <div class="border border-1 rounded-3 text-center">
+      <div class="border border-1 rounded-3 text-center mb-3">
         <div class="mt-2">
-          <%= link_to t(".children_infomation"), "#", class: "btn btn-primary custom-btn", role: "button" %>
+          <%= link_to t(".children_infomation"), user_children_path(current_user), class: "btn btn-primary custom-btn", role: "button" %>
         </div>
         <div class="mt-2">
           <%= link_to t(".email_change"), "#", class: "btn btn-secondary", role: "button" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
           <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
             <ul class="navbar-nav ms-auto my-2 mb-lg-0">
               <li class="nav-item">
-                <%= link_to t("defaults.user_menu"), menu_user_path(@user), class: "btn btn-primary custom-btn" %>
+                <%= link_to t("defaults.user_menu"), menu_user_path(current_user), class: "btn btn-primary custom-btn" %>
               </li>
             </ul>
           </div>
@@ -22,7 +22,10 @@
   <div class="row mb-3">
     <div class="col-md-10 col-lg-6 mx-auto">
       <div class="border border-1 rounded-3">
-        <%= render 'children/child', children: @children %>
+        <div class="mx-3 my-3 text-center" id="index-child">
+        <h4><%= t('children.child_index') %></h4>
+          <%= render 'children/child', children: @children %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -211,5 +211,9 @@ ja:
     please_register: お子さまを登録してください
     register_form: お子さま登録フォーム
     input_nickname: ニックネームを入力（全角10文字以下）
+    index:
+      title: お子さま登録状況一覧
+      edit: 編集
+      destroy: 登録を削除
     destroy:
       success: お子さまの登録を取り消しました


### PR DESCRIPTION
Closes #22 

## 実装内容

保護者メニューページからお子さま登録状況ページへの導線
ルーディング user/id/children_index
children_controllerにindexアクションを追記
views/children/index.html.erbを作成
お子さまの各名前の右側に'編集'ボタン、'登録の削除'ボタンを表示
ページ下部に'もどる'ボタンを設置

## 確認ポイント
- 登録の削除ボタンをクリックすると、「削除してよろしいですか」の確認メッセージが表示される
- 登録が削除されると「お子さまの登録を取り消しました」とフラッシュメッセージが表示される
- もどるボタンをクリックすると、保護者メニューページへ遷移する
- 保護者ページでは、子供の名前の横に'編集'ボタン、'登録の削除'ボタンは表示されない


## 補足
- 編集画面と、編集機能は後日実装

