### PR TITLE
お子さまの編集機能

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -15,6 +15,10 @@ class ChildrenController < ApplicationController
     end
   end
 
+  def edit
+    @child = current_user.children.find(params[:id])
+  end
+
   def destroy
     @child = current_user.children.find(params[:id])
     @child.destroy

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,8 +1,8 @@
 class ChildrenController < ApplicationController
-
+  
   def index
     @is_user_children = request.path == user_children_path(current_user)
-    @children = current_user.children
+    @children = current_user.children.order(id: :asc)
   end
   
   def create
@@ -17,6 +17,18 @@ class ChildrenController < ApplicationController
 
   def edit
     @child = current_user.children.find(params[:id])
+  end
+
+  def update
+    @child = current_user.children.find(params[:id])
+    
+    if @child.update(child_params)
+      redirect_to user_children_path(current_user), success: "成功したよ"
+    else
+      puts @child.errors.full_messages
+      flash.now[:danger] = "失敗したよ"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   
   def show
     @user = User.find(params[:id])
-    @children = current_user.children.order(created_at: :asc)
+    @children = current_user.children.order(id: :asc)
     @child = Child.new
   end
 

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -7,7 +7,7 @@ class Child < ApplicationRecord
   validates :name, length: { maximum: 10 }, format: { with: /\A[^\x01-\x7E]+\z/, message: "は全角文字のみで入力してください" }
   validates :name, uniqueness: { scope: :user_id }
   
-  validate :user_can_registor_less_than_three_children
+  validate :user_can_registor_less_than_three_children, on: :create
   validate :lists_limit
 
   private

--- a/app/views/children/_child.html.erb
+++ b/app/views/children/_child.html.erb
@@ -9,7 +9,7 @@
       <% if @is_user_children %>
         <div class="mx-3 d-flex">
           <%= link_to t('children.index.edit'), edit_child_path(child), class: "btn btn-primary btn-sm custom-btn mx-1", role: "button" %>
-          <%= link_to t('children.index.destroy'), child_path(child), class: "btn btn-primary btn-sm custom-btn mx-1", role: "button", data: { turbo_method: :delete, turbo_confirm: t("defaults.confirm_delete") } %>
+          <%= link_to t('children.index.destroy'), child_path(child), class: "btn btn-primary btn-sm custom-btn mx-1", role: "button", data: { turbo_method: :delete, turbo_confirm: t("defaults.confirm_delete_child") } %>
         </div>
       <% end %>
     </div>

--- a/app/views/children/edit.html.erb
+++ b/app/views/children/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-6 mx-auto">
+      <h5 class="mt-2"><%= t('.title') %></h5>
+      <div class="border border-1 rounded-3 text-center mb-3">
+        <div class="row py-3">
+          <%= form_with model: @child, local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>
+            
+            <%= f.label :name, t('children.edit_form'), class: "form-label" %>
+            <div class="container d-flex flex-sm-row flex-column justify-content-center align-items-center mb-3">
+              <%= f.text_field :name, class:"border border-warning border-5 rounded-3 text-center py-2", style:"width: 200px;" %>
+              <div class="mx-2">
+                <%= f.submit class: "btn btn-primary custom-btn", role: "button" %>
+              </div>
+            </div>
+          <% end %>  
+        
+          <div class="my-3">
+            <%= link_to t("defaults.previous_page"), menu_user_path(current_user), class: "btn btn-primary custom-btn", role: "button" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/children/edit.html.erb
+++ b/app/views/children/edit.html.erb
@@ -3,11 +3,11 @@
     <div class="col-md-10 col-lg-6 mx-auto">
       <h5 class="mt-2"><%= t('.title') %></h5>
       <div class="border border-1 rounded-3 text-center mb-3">
-        <div class="row py-3">
+        <div class="row">
           <%= form_with model: @child, local: true do |f| %>
             <%= render 'shared/error_messages', object: f.object %>
             
-            <%= f.label :name, t('children.edit_form'), class: "form-label" %>
+            <%= f.label :name, t('children.edit_form'), class: "form-label mt-3" %>
             <div class="container d-flex flex-sm-row flex-column justify-content-center align-items-center mb-3">
               <%= f.text_field :name, class:"border border-warning border-5 rounded-3 text-center py-2", style:"width: 200px;" %>
               <div class="mx-2">
@@ -17,7 +17,7 @@
           <% end %>  
         
           <div class="my-3">
-            <%= link_to t("defaults.previous_page"), menu_user_path(current_user), class: "btn btn-primary custom-btn", role: "button" %>
+            <%= link_to t("defaults.previous_page"), user_children_path(current_user), class: "btn btn-primary custom-btn", role: "button" %>
           </div>
         </div>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -210,10 +210,13 @@ ja:
     child_index: お子さま一覧
     please_register: お子さまを登録してください
     register_form: お子さま登録フォーム
+    edit_form: ニックネームを変更
     input_nickname: ニックネームを入力（全角10文字以下）
     index:
       title: お子さま登録状況一覧
       edit: 編集
       destroy: 登録を削除
+    edit:
+      title: ニックネーム編集
     destroy:
       success: お子さまの登録を取り消しました

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -184,6 +184,7 @@ ja:
   defaults:
     previous_page: もどる
     confirm_delete: 削除してよろしいですか？
+    confirm_delete_child: 削除してよろしいですか？(いままでのがんばりデータも削除されます)
     sign_up: アカウント登録
     sign_in: ログイン
     flash_message:


### PR DESCRIPTION
Closes #23 

## 実装内容
- ルーティング /users/:user_id/children/:id/edit
- お子さま登録状況ページからの導線
- controllers/children_controllerにeditアクションを追記
-  views/children/editの作成
- 編集・削除後はお子さま登録状況ページに遷移

## 補足
- destroy時に「削除の場合、お子さまの「いままでのがんばり」も消去されますがよろしいですか？」メッセージ表示
- editアクション時にカスタムバリデーションが引っかかってしまうので、一部変更を加える