### PR TITLE
コイン追加機能

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -42,6 +42,14 @@ body {
   transition: background-color 0.3s; /* ホバー時のトランジション */
 }
 
+.custom-box-gray {
+  background-color: #ffa464;
+  color: var(--bs-white);     
+  border: 3px solid #ffa464;
+  display: inline-block;
+  padding: 10px 20px;     
+  border-radius: 10px;
+}
 
 .name-btn {
   --bs-btn-bg: white; /* ボタンの背景色 */
@@ -65,7 +73,7 @@ body {
   color: #6c757d;          
   border: 5px solid #ffd233; 
   padding: 5px 10px;     
-  border-radius: 10px;     
+  border-radius: 10px;
   font-size: 17px;   
 }
 

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,6 +1,6 @@
 class ChildrenController < ApplicationController
   require "date"
-  before_action :set_child, only: %i[show edit update destroy]
+  before_action :set_child, only: %i[show edit update destroy update_list_and_coin]
   
   def index
     @children = current_user.children.order(id: :asc)
@@ -41,6 +41,27 @@ class ChildrenController < ApplicationController
   def destroy
     @child.destroy
     redirect_to children_path(current_user), status: :see_other, success: t('.success')
+  end
+
+  def update_list_and_coin
+    @list = @child.lists.find_by(id: params[:list_id])
+    @coin = Coin.find_by(child_id: @child.id)
+
+    if @coin
+      @coin.coin_amount += 1
+      @coin.save
+    else
+      redirect_to child_path(@child), danger: 'リストが見つからなかったよ' and return
+    end
+
+    if @list && @list.incomplete?
+      @list.completed!
+      @list.save
+    else
+      redirect_to child_path(@child), danger: 'リストが見つからなかったよ' and return
+    end
+
+    redirect_to child_path(@child), success: 'コインをゲットしたよ'
   end
 
   private

--- a/app/models/coin.rb
+++ b/app/models/coin.rb
@@ -1,3 +1,5 @@
 class Coin < ApplicationRecord
   belongs_to :child
+
+  validates :child_id, uniqueness: true
 end

--- a/app/views/lists/_list_have_coin.html.erb
+++ b/app/views/lists/_list_have_coin.html.erb
@@ -1,3 +1,6 @@
-<div class="list-box mb-1", style="width: 200px;">
-  <%= image_tag 'coin.png', height: "50" %><%= list.name %></br>
-</div>
+<%= link_to list_path(list, child_id: child.id), class: "btn btn-primary list-btn mb-1", style: "width: 200px;" do %>
+  <div class="d-flex justify-content-between align-items-center">
+    <%= list.name %>
+    <%= image_tag 'coin.png', height: "50" %>
+  </div>
+<% end %>

--- a/app/views/lists/_list_no_coin.html.erb
+++ b/app/views/lists/_list_no_coin.html.erb
@@ -1,1 +1,1 @@
-<%= link_to list.name, list_path(list_id: list.id, child_id: child.id), class:"btn btn-primary list-btn mb-1", style: "width: 200px;" %></br>
+<%= link_to list.name, list_path(list, child_id: child.id), class:"btn btn-primary list-btn mb-1", style: "width: 200px;" %></br>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -12,7 +12,7 @@
           <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
             <ul class="navbar-nav ms-auto my-2 mb-lg-0">
               <li class="nav-item">
-                <%= link_to 'リストを編集',"#", class: "btn btn-primary custom-btn mb-2" %>
+                <%= link_to t('defaults.list_edit'),"#", class: "btn btn-primary custom-btn mb-2" %>
               </li>
             </ul>
           </div>
@@ -32,9 +32,15 @@
 <div class="container">
   <div class="row">
     <div class="col-sm-10 col-lg-10 mx-auto">
-      <% if @tasks.all? { |task| task.status == "completed" } %>
+      <% if @tasks.all? { |task| task.status == "completed" } && @list.incomplete? %>
         <div class= "text-center">
-          <%= link_to 'コインを獲得する', "#", class: "btn btn-primary custom-btn-2 my-3", role: "button" %>
+          <%= link_to t('defaults.get_coin'), update_list_and_coin_child_path(@child, list_id: @list.id), data: { turbo_method: :patch }, class: "btn btn-primary custom-btn-2 my-3", role: "button" %>
+        </div>
+      <% elsif @tasks.all? { |task| task.status == "completed" } && @list.completed? %>
+        <div class= "text-center">
+          <div class="custom-box-gray mb-2">
+            <%= t('defaults.you_got_coin') %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -194,6 +194,9 @@ ja:
     user_menu: 保護者メニュー
     did_it_record: いままでのがんばり
     list_create: リストを追加
+    list_edit: リストを編集
+    get_coin: コインをゲット！！
+    you_got_coin: コイン獲得済みだよ
   activerecord:
     models:
       child: お子さま
@@ -235,4 +238,5 @@ ja:
       year: ねん
       month: がつ
       day: にち
+  lists: 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
 
   resources :children do
     resources :lists, shallow: true
+    member do
+      patch 'update_list_and_coin'
+    end
   end
 
   resources :tasks do
@@ -22,4 +25,5 @@ Rails.application.routes.draw do
       patch :change_status
     end
   end
+  
 end


### PR DESCRIPTION
Closes #28

## 実装内容
「コインをゲット！！」ボタンをクリック時
coinの枚数が一枚増えて、listのstatusがcompletedに変更されるように実装する

- ルーティング  'update_list_and_coin'を追加
- controllers/children_controllerに 'update_list_and_coin'アクションを追記
- 「コイン獲得」ボタンクリック後はお子さま用マイページに遷移する
- お子さま用マイページのリスト名の横にコインマークが表示される
- お子さま用マイページのコイン数が1枚増える
- コイン獲得後のコイン獲得ボタンは「コイン獲得済みだよ」と表示クリックはできなくなる