### PR TITLE
Feature/completed tasks page

### DIFF
--- a/app/controllers/completed_tasks_controller.rb
+++ b/app/controllers/completed_tasks_controller.rb
@@ -1,0 +1,6 @@
+class CompletedTasksController < ApplicationController
+  def index
+    @child = Child.find(params[:child_id])
+  end
+   
+end

--- a/app/controllers/completed_tasks_controller.rb
+++ b/app/controllers/completed_tasks_controller.rb
@@ -1,6 +1,6 @@
 class CompletedTasksController < ApplicationController
   def index
     @child = Child.find(params[:child_id])
+    @completed_tasks = @child.completed_tasks
   end
-   
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,9 +1,22 @@
 class TasksController < ApplicationController
+  after_action :increment_completed_task_count, if: :status_completed?
 
-  def change_status   
+  def change_status
     @task = Task.find(params[:id])
     @task.completed! if @task.incomplete?
     
-    redirect_to list_path(@task.list_id)
+    redirect_to list_path(@task.list_id) and return
+  end
+
+  private
+
+  def status_completed?
+    @task.completed?
+  end
+
+  def increment_completed_task_count
+    completed_task = CompletedTask.find_or_initialize_by(task_body: @task.body, child_id: @task.list.child.id)
+    completed_task.completed_count += 1
+    completed_task.save
   end
 end

--- a/app/models/completed_task.rb
+++ b/app/models/completed_task.rb
@@ -1,6 +1,5 @@
 class CompletedTask < ApplicationRecord
   belongs_to :child
-  belongs_to :task
 
-  validates :task_id, uniqueness: { scope: :list_id }
+  validates :task_body, uniqueness: { scope: :child_id }
 end

--- a/app/views/children/show.html.erb
+++ b/app/views/children/show.html.erb
@@ -54,7 +54,7 @@
     </div>
       
     <div class= "text-center">
-      <%= link_to t('defaults.did_it_record'), "#", class: "btn btn-primary custom-btn-2 my-3", role: "button" %>
+      <%= link_to t('defaults.did_it_record'), child_completed_tasks_path(child_id: @child.id), class: "btn btn-primary custom-btn-2 my-3", role: "button" %>
     </div>
   </div>
 </div>

--- a/app/views/completed_tasks/index.html.erb
+++ b/app/views/completed_tasks/index.html.erb
@@ -1,5 +1,28 @@
-<h1>completed_tasks index</h1>
+<div class="container">
+  <div class="row d-flex justify-content-center my-3">
+    <div class="name-box text-center" style="width: 200px;" > 
+      <%= @child.name %>
+    </div>
+  </div>
+</div>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-10 col-lg-10 mx-auto text-center">
+      <h5 class=mx-3><%= t('defaults.did_it_record') %></h5>
+        <% @completed_tasks.each do|ct| %>
+            <div class="d-flex justify-content-between align-items-center mx-auto" style="width: 200px;">
+              <div>
+                <%= ct.task_body %>
+              </div>
+              <div>
+                <%= "#{ct.completed_count}かい" %>
+              </div>
+            </div>
+        <% end %>
+    </div>
+  </div>
+</div>
 
-<div class= "text-center">  
+<div class= "text-center mt-3">  
   <%= link_to t("defaults.previous_page"), child_path(@child), class: "btn btn-primary custom-btn", role: "button" %>
 </div>

--- a/app/views/completed_tasks/index.html.erb
+++ b/app/views/completed_tasks/index.html.erb
@@ -1,0 +1,5 @@
+<h1>completed_tasks index</h1>
+
+<div class= "text-center">  
+  <%= link_to t("defaults.previous_page"), child_path(@child), class: "btn btn-primary custom-btn", role: "button" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   resources :children do
     resources :lists, shallow: true
+    resources :completed_tasks, only: %i[index]
     member do
       patch 'update_list_and_coin'
     end

--- a/db/migrate/20240818054749_update_completed_tasks.rb
+++ b/db/migrate/20240818054749_update_completed_tasks.rb
@@ -1,0 +1,7 @@
+class UpdateCompletedTasks < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :completed_tasks, :task_id, :integer
+    add_column :completed_tasks, :task_body, :string
+    change_column_default :completed_tasks, :completed_count, from: 0, to: 1
+  end
+end

--- a/db/migrate/20240818055428_add_not_null_to_task_body_in_completed_tasks.rb
+++ b/db/migrate/20240818055428_add_not_null_to_task_body_in_completed_tasks.rb
@@ -1,0 +1,5 @@
+class AddNotNullToTaskBodyInCompletedTasks < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :completed_tasks, :task_body, false
+  end
+end

--- a/db/migrate/20240818060114_add_unique_index_to_completed_tasks.rb
+++ b/db/migrate/20240818060114_add_unique_index_to_completed_tasks.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToCompletedTasks < ActiveRecord::Migration[7.1]
+  def change
+    add_index :completed_tasks, [:child_id, :task_body], unique: true
+  end
+end

--- a/db/migrate/20240819011705_change_default_completed_count_in_completed_tasks.rb
+++ b/db/migrate/20240819011705_change_default_completed_count_in_completed_tasks.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultCompletedCountInCompletedTasks < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :completed_tasks, :completed_count, from: 1, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_15_022657) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_18_060114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,13 +33,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_022657) do
 
   create_table "completed_tasks", force: :cascade do |t|
     t.bigint "child_id"
-    t.bigint "task_id"
-    t.integer "completed_count", default: 0, null: false
+    t.integer "completed_count", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["child_id", "task_id"], name: "index_completed_tasks_on_child_id_and_task_id", unique: true
+    t.string "task_body", null: false
+    t.index ["child_id", "task_body"], name: "index_completed_tasks_on_child_id_and_task_body", unique: true
     t.index ["child_id"], name: "index_completed_tasks_on_child_id"
-    t.index ["task_id"], name: "index_completed_tasks_on_task_id"
   end
 
   create_table "lists", force: :cascade do |t|
@@ -76,7 +75,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_022657) do
   add_foreign_key "children", "users"
   add_foreign_key "coins", "children"
   add_foreign_key "completed_tasks", "children"
-  add_foreign_key "completed_tasks", "tasks"
   add_foreign_key "lists", "children"
   add_foreign_key "tasks", "lists"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_18_060114) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_19_011705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,7 +33,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_18_060114) do
 
   create_table "completed_tasks", force: :cascade do |t|
     t.bigint "child_id"
-    t.integer "completed_count", default: 1, null: false
+    t.integer "completed_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "task_body", null: false


### PR DESCRIPTION
Closes #25

### 実装内容
- completed_tasksテーブルカラム修正
  - "task_id"を削除
  - task_bodyカラムを追加
  - task_bodyカラムにnot_null: falseを追加
  - task_bodyとchild_idにユニーク制約を追加

- ルーティング
  - ルーティング(completed_tasks/index)を追加
  - controllers/completed_tasks.rbにindexアクションを追加
  - views/completed_tasks/index.html.erbを作成
  - お子さま用マイページからの導線
  - もどるボタンでお子さま用マイページへ遷移

- controller
  - completed_tasks_controllerにindexアクション定義
  - tasks_controllerに以下の実装を追加
    - after_actionを追加
    - increment_completed_task_count、status_completed?を追加
    - （@childと紐づくcompleted_taskのcompleted_countに1を加える、@childと紐づくcompleted_taskがないときは新しく作成する）