### PR TITLE
リスト編集・削除機能

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -24,7 +24,7 @@ class ChildrenController < ApplicationController
   end
 
   def show
-    @lists = @child.lists
+    @lists = @child.lists.order(id: :asc)
   end
 
   def edit; end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -21,6 +21,8 @@ class ListsController < ApplicationController
     @tasks = @list.tasks
   end
 
+  def edit; end
+
   def destroy
     @list.destroy
     redirect_to child_path(@child), status: :see_other

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,27 +1,52 @@
 class ListsController < ApplicationController
-  before_action :set_child, only: %i[new create show destroy]
-  before_action :set_list, only: %i[show destroy]
+  before_action :set_list, only: %i[show edit update destroy]
+  before_action :set_child, only: %i[show edit update destroy]
 
   def new
     @list = List.new
+    @child = Child.find_by(id: params[:child_id])
     4.times { @list.tasks.build}
   end
 
   def create
+    @child = Child.find_by(id: params[:child_id])
     @list = @child.lists.build(list_params)
 
     if @list.save
       redirect_to child_path(@child)
     else
+      tasks_attributes = params[:list][:tasks_attributes].to_unsafe_h
+      empty_bodies_count = tasks_attributes.select { |_, task| task[:body].empty? }.size
+      empty_bodies_count.times {@list.tasks.build}
       render :new, status: :unprocessable_entity
     end
   end
 
   def show
-    @tasks = @list.tasks
+    @tasks = @list.tasks.order(id: :asc)
   end
 
-  def edit; end
+  def edit
+    (4 - @list.tasks.count).times do
+      @list.tasks.build
+    end
+  end
+
+  def update
+    # tasks_attributesからbodyが空のタスクを削除する
+    params[:list][:tasks_attributes].each do |key, task_params|
+      if task_params[:body].blank?
+        task_params[:_destroy] = '1' 
+      end
+    end
+
+    if @list.update(list_params)
+      redirect_to list_path(@list), success: "成功したよ"
+    else
+      flash.now[:danger] = "失敗したよ"
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   def destroy
     @list.destroy
@@ -31,7 +56,7 @@ class ListsController < ApplicationController
   private
 
   def set_child
-    @child = Child.find(params[:child_id]) 
+    @child = @list.child
   end
 
   def set_list
@@ -39,6 +64,6 @@ class ListsController < ApplicationController
   end
 
   def list_params
-    params.require(:list).permit(:name, tasks_attributes: [:body])
+    params.require(:list).permit(:name, tasks_attributes: [:id, :body, :_destroy])
   end
 end

--- a/app/views/lists/_list_have_coin.html.erb
+++ b/app/views/lists/_list_have_coin.html.erb
@@ -1,4 +1,4 @@
-<%= link_to list_path(list, child_id: child.id), class: "btn btn-primary list-btn mb-1", style: "width: 200px;" do %>
+<%= link_to list_path(list), class: "btn btn-primary list-btn mb-1", style: "width: 200px;" do %>
   <div class="d-flex justify-content-between align-items-center">
     <%= list.name %>
     <%= image_tag 'coin.png', height: "50" %>

--- a/app/views/lists/_list_no_coin.html.erb
+++ b/app/views/lists/_list_no_coin.html.erb
@@ -1,1 +1,1 @@
-<%= link_to list.name, list_path(list, child_id: child.id), class:"btn btn-primary list-btn mb-1", style: "width: 200px;" %></br>
+<%= link_to list.name, list_path(list), class:"btn btn-primary list-btn mb-1", style: "width: 200px;" %></br>

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,1 +1,42 @@
-<h1>lists_edit</h1>
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-8 mx-auto">
+      <nav class="navbar navbar-expand-sm">
+        <div class="container-fluid">
+          <h5>やることリスト編集</h5>
+          <div>
+            <%= link_to t('defaults.list_destroy'), list_path(@list), class: "btn btn-primary custom-btn btn-sm mb-2", role: "button", data: { turbo_method: :delete, turbo_confirm: t("defaults.confirm_delete") }  %>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </div>
+</div>
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-8 mx-auto">
+      <div class="border border-1 rounded-3 my-2 py-2 px-2">
+        <%= form_with model: @list, local: true do |f| %>
+          <%= render 'shared/error_messages', object: f.object %>
+          <div class="mb-3">
+            <%= f.label :name, class: "form-label" %>
+            <%= f.text_field :name, class: "list-box shadow", style: "width: 200px;" %>
+          </div>
+
+          <div class="mb-3">
+            <%= f.fields_for :tasks do |task_form| %>
+              <div>
+                <%= task_form.label :body, class: "form-label" %>
+                <%= task_form.text_field :body, class: "form-control" %>
+              </div>
+            <% end %>
+          </div>
+          <%= f.submit nil, class:"btn btn-primary custom-btn" %> 
+        <% end %>
+      </div>
+      <div class="text-center">
+        <%= link_to t("defaults.previous_page"), list_path(@list), class: "btn btn-primary custom-btn", role: "button" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,0 +1,1 @@
+<h1>lists_edit</h1>

--- a/app/views/lists/new.html.erb
+++ b/app/views/lists/new.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto">
       <div class="border border-1 rounded-3 my-2 py-2 px-2">
-        <h5>やることリスト作成</h5>
+        <h5><%= t('.title') %></h5>
 
         <%= form_with model: @list, url: child_lists_path, local: true do |f| %>
           <%= render 'shared/error_messages', object: f.object %>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -12,7 +12,7 @@
           <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
             <ul class="navbar-nav ms-auto my-2 mb-lg-0">
               <li class="nav-item">
-                <%= link_to t('defaults.list_edit'),"#", class: "btn btn-primary custom-btn mb-2" %>
+                <%= link_to t('defaults.list_edit'), edit_list_path(@list), class: "btn btn-primary custom-btn mb-2" %>
               </li>
             </ul>
           </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -195,6 +195,7 @@ ja:
     did_it_record: いままでのがんばり
     list_create: リストを追加
     list_edit: リストを編集
+    list_destroy: リストを削除
     get_coin: コインをゲット！！
     you_got_coin: コイン獲得済みだよ
   activerecord:
@@ -238,5 +239,6 @@ ja:
       year: ねん
       month: がつ
       day: にち
-  lists: 
-
+  lists:
+      new:
+        title: やることリスト作成


### PR DESCRIPTION
 Closes #27 

 
## 実装内容
ルーティング（list#edit）
- lists/showページからの導入
- controllers/lists_contoroller_controllerにeditアクションを追加
- views/lists/edit.html.erbの作成

controller
- views/editで元々taskが2つの場合でも、f.fields_for :tasksが4つ表示されるようにする
- 既存のtaskがあった欄をブランクにした場合でも登録ができるようにする
- updateした後はlists/showページへ遷移する
