### PR TITLE
rakeタスク実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,13 +47,15 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'devise'
+gem 'devise-i18n'
+
+gem 'whenever', require: false
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
 end
-
-gem 'devise'
-gem 'devise-i18n'
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -256,6 +257,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.16)
@@ -286,6 +289,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  whenever
 
 RUBY VERSION
    ruby 3.2.3p157

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -24,7 +24,7 @@ class ChildrenController < ApplicationController
   end
 
   def show
-    @lists = @child.lists.order(id: :asc)
+    @lists = @child.lists.created_at_today.order(id: :asc)
   end
 
   def edit; end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -5,17 +5,9 @@ class List < ApplicationRecord
   accepts_nested_attributes_for :tasks, allow_destroy: true, reject_if: :all_blank, limit: 4
 
   validates :name, presence: true, length: { maximum: 10 }
-  validates :name, uniqueness: { scope: :child_id }
 
-  validate :lists_limit
+  scope :created_at_today, -> { where(created_at: Time.current.all_day) }
   
   enum status: { incomplete: 0, completed: 1 }
   
-  private
-
-  def lists_limit
-    if child.lists.size > 3
-      errors.add(:lists, "は3個まで登録できます")
-    end
-  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module DidIt
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
     # 追記
     config.generators do |g|

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,7 +1,13 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
+# Rails.rootを使用するために必要
+
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+# cronを実行する環境変数周りの設定
+ENV.each { |k, v| env(k, v) }
+rails_env = ENV['RAILS_ENV'] || :development
+# cronを実行する環境変数をセット
+set :environment, rails_env
+# cronのログの吐き出し場所
+set :output, "#{Rails.root}/log/cron.log"
 
 # Example:
 #
@@ -18,3 +24,6 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
+every 1.day, at: '0:00 am' do
+  rake 'create_list_tasks:recreate_lists_and_tasks'
+end

--- a/db/migrate/20240821073350_delete_child_id_name_uniq_index_from_lists.rb
+++ b/db/migrate/20240821073350_delete_child_id_name_uniq_index_from_lists.rb
@@ -1,0 +1,5 @@
+class DeleteChildIdNameUniqIndexFromLists < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :lists, [:child_id, :name]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_19_011705) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_21_073350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,7 +47,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_19_011705) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["child_id", "name"], name: "index_lists_on_child_id_and_name", unique: true
     t.index ["child_id"], name: "index_lists_on_child_id"
   end
 

--- a/lib/tasks/create_list_tasks.rake
+++ b/lib/tasks/create_list_tasks.rake
@@ -1,0 +1,24 @@
+namespace :create_list_tasks do
+  desc '毎日0時に全てのlistsとtasksを再作成し、おとといのものを削除する'
+  task recreate_lists_and_tasks: :environment do
+    # 1. おとといに作成されたリストとタスクを削除する処理
+    List.where("created_at < ?", 1.day.ago.midnight).destroy_all
+    Task.where("created_at < ?", 1.day.ago.midnight).destroy_all
+
+    # 2. 全てのchildrenに対して新しいリストとタスクを作成する処理
+    Child.find_each do |child|
+      # 既存のリストを取得し、新しいリストを作成
+      existing_lists = child.lists
+      new_lists = existing_lists.map do |list|
+        new_list = List.create(child: child, name: list.name)
+
+        # 3. 既存のタスクを取得し、新しいタスクを作成する処理
+        list.tasks.each do |task|
+          Task.create(list: new_list, body: task.body)
+        end
+
+        new_list
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #69

## 実装内容
毎日0時に
全てのchildに紐づくlistsとそれに紐づくtaskを本日分として再作成し、古いlistを削除するrakeタスクを実装する

- cron, wheneverのインストール
- rakeファイル作成、実装
  2日前までのlists&taskを削除
  全ての子供に紐づくlistsと同じ名前を持つlistsを再作成
  そのリストに紐づくtasksと同じbodyを持つtasksを再作成
- schedule.rbの実装
  毎日0時に実行されるように設定
- did_itアプリのtime zoneをTokyoにする
- list.rbのバリデーションが、lists再作成の際に引っかかってしまうので、一度バリデーションを削除 
